### PR TITLE
Allow to use a different goss_test_directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ base_goss
 ---------
 
 An ansible-role to download the **goss** binary to a dir set by {{ goss_path }}.
-The `validate` tag runs health checks by parsing `/root/test_*.yml` files created by other roles.
+The `validate` tag runs health checks by parsing `{{ goss_test_directory }}/test_*.y*ml` files created by other roles.
 These are used to validate the server/container against specifications.
 
 [http://goss.rocks](http://goss.rocks)
@@ -23,6 +23,7 @@ Role Variables
     goss_dst: /usr/bin/goss
     goss_url: "https://github.com/aelsabbahy/goss/releases/download/{{ goss_version }}/goss-linux-{{ goss_arch }}"
     goss_test_directory: /root
+    goss_test_directory_mode: 0700
     goss_format: tap
 
 Any new versions of `goss_version` need to be handjammed into `vars/main.yml` because of the manual checksum validation. Currently all known versions are supported.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,4 +6,5 @@ goss_arch: amd64
 goss_dst: /usr/bin/goss
 goss_url: "https://github.com/aelsabbahy/goss/releases/download/{{ goss_version }}/goss-linux-{{ goss_arch }}"
 goss_test_directory: /root
+goss_test_directory_mode: 0700
 goss_format: tap

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,27 +43,28 @@
   tags:
     - base_goss
 
-- name: "copy test_goss.yml to remote"
+- name: "ensure {{ goss_test_directory }} exists"
+  file:
+    path: "{{ goss_test_directory }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "{{ goss_test_directory_mode }}"
+
+- name: "copy test_goss.yaml to remote"
   template:
-    src: goss.yaml
-    dest: "/root/test_goss.yml"
+    src: test_goss.yaml.j2
+    dest: "{{ goss_test_directory }}/test_goss.yaml"
   tags:
     - base_goss
 
-- name: "verify if /root/goss.yaml exists"
-  stat:
-    path: /root/goss.yaml
-  register: yamlfile
-  tags:
-    - base_goss
-
-- name: "render goss.yaml on remote"
-  script: goss_render.sh
-  when: not yamlfile.stat.exists
+- name: "copy goss.yaml to remote"
+  template:
+    src: goss.yaml.j2
+    dest: "/root/goss.yaml"
   tags:
     - base_goss
     - validate
-
 
 - name: Execute Goss tests
   command: "{{ goss_dst }} -g /root/goss.yaml validate --format {{ goss_format }}"

--- a/templates/goss.yaml.j2
+++ b/templates/goss.yaml.j2
@@ -1,0 +1,2 @@
+gossfile:
+  {{ goss_test_directory }}/test_*.y*ml: {}

--- a/templates/test_goss.yaml.j2
+++ b/templates/test_goss.yaml.j2
@@ -6,7 +6,7 @@ file:
     owner: root
     group: root
     filetype: file
-  "{{ goss_path }}goss":
+  "{{ goss_path }}/goss":
     exists: true
     owner: root
     group: root


### PR DESCRIPTION
* Replace `goss_render.sh` with template

I think we can replace the script. This role brings it's own test so the glob always matches at least one file and doesn't fail. 

Having no tests is anyway not supported by goss:
```
TASK [dockpack.base_goss : Execute Goss tests] ******************************************************
fatal: [jabber.systemli.org]: FAILED! => {"changed": false, "cmd": ["/usr/local/bin/goss", "-g", "/root/goss.yaml", "validate", "--format", "tap"], "delta": "0:00:00.005130", "end": "2019-05-27 11:49:36.585700", "msg": "non-zero return code", "rc": 1, "start": "2019-05-27 11:49:36.580570", "stderr": "", "stderr_lines": [], "stdout": "Error: found 0 tests, source: /root/goss.yaml", "stdout_lines": ["Error: found 0 tests, source: /root/goss.yaml"]}
```

For example, I'm running your great role with the following parametes:

```
goss_test_directory: /etc/goss.d/
goss_test_directory_mode: 0755
goss_path: /usr/local/bin
goss_dst: /usr/local/bin/goss
```