### PR TITLE
Show only failing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These are used to validate the server/container against specifications.
 Requirements
 ------------
 
-Linux machine.
+Linux machine. The machine running ansible must have `python-jmespath` installed.
 
 Role Variables
 --------------
@@ -24,7 +24,6 @@ Role Variables
     goss_url: "https://github.com/aelsabbahy/goss/releases/download/{{ goss_version }}/goss-linux-{{ goss_arch }}"
     goss_test_directory: /root
     goss_test_directory_mode: 0700
-    goss_format: tap
 
 Any new versions of `goss_version` need to be handjammed into `vars/main.yml` because of the manual checksum validation. Currently all known versions are supported.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,4 +7,3 @@ goss_dst: /usr/bin/goss
 goss_url: "https://github.com/aelsabbahy/goss/releases/download/{{ goss_version }}/goss-linux-{{ goss_arch }}"
 goss_test_directory: /root
 goss_test_directory_mode: 0700
-goss_format: tap

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 tox
 molecule
 docker
+jmespath

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,28 +86,24 @@
     - base_goss
     - validate
 
-- name: Execute Goss tests
-  command: "{{ goss_dst }} -g /root/goss.yaml validate --format {{ goss_format }}"
+- block:
+    - name: Execute Goss tests
+      command: "{{ goss_dst }} -g /root/goss.yaml validate --format json"
+      register: test_results
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: Show failing Goss tests
+      debug:
+        msg: "Goss test failed"
+      loop: "{{ test_results.stdout | from_json | json_query(query) }}"
+      vars:
+        query: 'results[?successful==`false`]."summary-line"'
+      when: test_results.rc != 0
+      failed_when: test_results.rc != 0
+
   when: goss_bin_remote.stat.exists
-  register: test_results
-  changed_when: false
-  check_mode: false
-  ignore_errors: true
-  tags:
-    - base_goss
-    - validate
-
-- name: Display details about the Goss results
-  debug:
-    msg: "{{ test_results.stdout_lines }}"
-  tags:
-    - base_goss
-    - validate
-
-- name: Fail when tests fail
-  fail:
-    msg: "Goss failed to validate"
-  when: test_results.rc != 0
   tags:
     - base_goss
     - validate


### PR DESCRIPTION
This pull request fixes  `goss_format=json` in order to allow to search the test results for test that have failed. It only shows failed tests then.

A failing output will look like this:
```
TASK [dockpack.base_goss : Execute Goss tests] ******************************************************
ok: [host.example.org]

TASK [dockpack.base_goss : Show failing Goss tests] *************************************************
failed: [host.example.org] (item=File: /usr/local/bin/goss: owner:
Expected
    <string>: ansible
to equal
    <string>: root) => {
    "msg": "Goss test failed"
}
fatal: [host.example.org]: FAILED! => {"msg": "All items completed"}

PLAY RECAP ******************************************************************************************
host.example.org        : ok=3    changed=0    unreachable=0    failed=1
```

Good output will look like this:
```
TASK [dockpack.base_goss : Execute Goss tests] ******************************************************
ok: [host.example.org]

TASK [dockpack.base_goss : Show failing Goss tests] *************************************************

PLAY RECAP ******************************************************************************************
host.example.org        : ok=3    changed=0    unreachable=0    failed=0
```

I believe this output is much more actionable then before.