### PR TITLE
Set owner and mode explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Role Variables
     goss_test_directory: /root
     goss_test_directory_mode: 0700
     goss_format: tap
+    goss_user: root
 
 Any new versions of `goss_version` need to be handjammed into `vars/main.yml` because of the manual checksum validation. Currently all known versions are supported.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ goss_url: "https://github.com/aelsabbahy/goss/releases/download/{{ goss_version 
 goss_test_directory: /root
 goss_test_directory_mode: 0700
 goss_format: tap
+goss_user: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,8 @@
   copy:
     src: "/tmp/goss"
     dest: "{{ goss_path }}/goss"
+    owner: "{{ goss_user }}"
+    group: "{{ goss_user }}"
     mode: 0755
   when: goss_bin.stat.exists
   tags:
@@ -57,8 +59,8 @@
   file:
     path: "{{ goss_test_directory }}"
     state: directory
-    owner: root
-    group: root
+    owner: "{{ goss_user }}"
+    group: "{{ goss_user }}"
     mode: "{{ goss_test_directory_mode }}"
   tags:
     - base_goss

--- a/templates/test_goss.yaml.j2
+++ b/templates/test_goss.yaml.j2
@@ -3,12 +3,12 @@ file:
   /root/goss.yaml:
     exists: true
     mode: "0644"
-    owner: root
-    group: root
+    owner: "{{ goss_user }}"
+    group: "{{ goss_user }}"
     filetype: file
   "{{ goss_path }}/goss":
     exists: true
-    owner: root
-    group: root
+    owner: "{{ goss_user }}"
+    group: "{{ goss_user }}"
     mode: "0755"
     sha256: "{{ goss[goss_version].sha256sum }}"


### PR DESCRIPTION
You're test check for owner and group to be `root`. Therefore, we should set it explicitly.