### PR TITLE
Delete variable `goss_dst`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Role Variables
     goss_version: "v0.3.7"
     goss_path: "/usr/bin/"
     goss_arch: amd64
-    goss_dst: /usr/bin/goss
     goss_url: "https://github.com/aelsabbahy/goss/releases/download/{{ goss_version }}/goss-linux-{{ goss_arch }}"
     goss_test_directory: /root
     goss_test_directory_mode: 0700

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,10 +3,8 @@
 goss_version: "v0.3.7"
 goss_path: "/usr/bin/"
 goss_arch: amd64
-goss_dst: /usr/bin/goss
 goss_url: "https://github.com/aelsabbahy/goss/releases/download/{{ goss_version }}/goss-linux-{{ goss_arch }}"
 goss_test_directory: /root
 goss_test_directory_mode: 0700
-goss_format: tap
 goss_user: root
 goss_install_dgoss: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,7 +83,7 @@
 
 - name: Ensure we have remote copy of goss
   stat:
-    path: "{{ goss_dst }}"
+    path: "{{ goss_path }}/goss"
   register: goss_bin_remote
   tags:
     - base_goss
@@ -91,7 +91,7 @@
 
 - block:
     - name: Execute Goss tests
-      command: "{{ goss_dst }} -g /root/goss.yaml validate --format json"
+      command: "{{ goss_path }}/goss -g /root/goss.yaml validate --format json"
       register: test_results
       changed_when: false
       failed_when: false


### PR DESCRIPTION
This variable is actually configured in an earlier task
by `{{ goss_path }}/goss`. So we should continue to use that.

Also, delete leftover default of `goss_format`