### PR TITLE
Ansible later

### DIFF
--- a/.later.yml
+++ b/.later.yml
@@ -1,0 +1,17 @@
+---
+ansible:
+  # Add the name of used custom Ansible modules. Otherwise ansible-later
+  # can't detect unknown modules and will through an error.
+  # Modules which are bundled with the role and placed in a './library'
+  # directory will be auto-detected and don't need to be added to this list.
+  custom_modules: []
+
+  # List of yamllint compatible literal bools (ANSIBLE0014)
+  literal-bools:
+    - "true"
+    - "false"
+rules:
+  exclude_files:
+    - molecule/
+    - requirements.txt
+...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # defaults file for install_goss
+# Standards: 0.2
 goss_version: "v0.3.10"
 goss_path: "/usr/bin/"
 goss_arch: amd64
@@ -12,3 +13,4 @@ goss_format: tap
 goss_user: root
 goss_install_dgoss: true
 goss_download: localhost
+...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+# Standards: 0.2
 galaxy_info:
   role_name: base_goss
   namespace: dockpack
@@ -26,3 +27,4 @@ galaxy_info:
   galaxy_tags: []
 
 dependencies: []
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+# tasks for base_goss
+# Standards: 0.2
 # yamllint disable rule:line-length
 - name: Install ca-certificates
   apt:
@@ -35,7 +37,7 @@
     - base_goss
 
 - block:
-    - name: "get goss binary"
+    - name: Get goss binary
       become: false
       delegate_to: localhost
       get_url:
@@ -60,7 +62,7 @@
       tags:
         - base_goss
 
-    - name: "copy goss to remote"
+    - name: Copy goss to remote
       copy:
         src: "/tmp/goss"
         dest: "{{ goss_path }}/goss"
@@ -72,7 +74,7 @@
         - base_goss
   when: goss_download == 'localhost'
 
-- name: "get goss binary directly"
+- name: Get goss binary directly
   get_url:
     url: "https://github.com/aelsabbahy/goss/releases/download/{{ goss_version }}/goss-linux-amd64"
     sha256sum: "{{ goss[goss_version].sha256sum }}"
@@ -89,7 +91,7 @@
   tags:
     - base_goss
 
-- name: "copy dgoss to remote"
+- name: Copy dgoss to remote
   copy:
     src: "dgoss"
     dest: "{{ goss_path }}/dgoss"
@@ -99,7 +101,7 @@
   tags:
     - base_goss
 
-- name: "ensure {{ goss_test_directory }} exists"
+- name: "Ensure {{ goss_test_directory }} exists"
   file:
     path: "{{ goss_test_directory }}"
     state: directory
@@ -109,7 +111,7 @@
   tags:
     - base_goss
 
-- name: "copy test_goss.yaml to remote"
+- name: Copy test_goss.yaml to remote
   template:
     src: test_goss.yaml.j2
     dest: "{{ goss_test_directory }}/test_goss.yaml"
@@ -117,7 +119,7 @@
   tags:
     - base_goss
 
-- name: "copy goss.yaml to remote"
+- name: Copy goss.yaml to remote
   template:
     src: goss.yaml.j2
     dest: "/root/goss.yaml"
@@ -155,3 +157,4 @@
   tags:
     - base_goss
     - validate
+...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 # vars file for install_goss
+# Standards: 0.2
 goss:
   v0.3.10:
     sha256sum: 150f25495ca0d1d4fd2ef8d0e750dbd767a15e9a522505f99b61dd1dd40a76d4
@@ -25,3 +26,4 @@ goss:
     sha256sum: d1ff74a14bccba4a016e66ef7023789582cc9923dd3a55aa5ea0c02b371b0a79
   v0.2.5:
     sha256sum: 31d04f98444ded26e2478fbdb3f5949cc9318bed13b5937598facc1818e1fce1
+...


### PR DESCRIPTION
ansible-later is a best practice scanner and linting tool. In most cases, if you write Ansible roles in a team, it helps to have a coding or best practice guideline in place. This will make Ansible roles more readable for all maintainers and can reduce the troubleshooting time. While ansible-later aims to be a fast and easy to use linting tool for your Ansible resources, it might not be that feature completed as required in some situations. If you need a more in-depth analysis you can take a look at ansible-lint.

ansible-later does not ensure that your role will work as expected. For deployment tests you can use other tools like molecule.

You can find the full documentation at https://ansible-later.geekdocs.de.