### PR TITLE
Fix unsupported param: sha256sum -> checksum

### DIFF
--- a/tasks/present.yml
+++ b/tasks/present.yml
@@ -45,7 +45,7 @@
 - name: Get goss binary directly
   get_url:
     url: "{{ goss_url }}"
-    sha256sum: "{{ goss[goss_version].sha256sum }}"
+    checksum: "sha256:{{ goss[goss_version].sha256sum }}"
     validate_certs: false
     dest: "{{ goss_path }}/goss"
     owner: "{{ goss_user }}"


### PR DESCRIPTION
The former has been deprecated since ansible 2.9, and was dropped in newer releases: it leads to an error with ansible 2.14.